### PR TITLE
Choosing the number of variables to draw arrows for

### DIFF
--- a/R/ggbiplot.r
+++ b/R/ggbiplot.r
@@ -37,6 +37,7 @@
 #' @param varname.size    size of the text for variable names
 #' @param varname.adjust  adjustment factor the placement of the variable names, >= 1 means farther from the arrow
 #' @param varname.abbrev  whether or not to abbreviate the variable names
+#' @param nvars           number of variables to plot
 #'
 #' @return                a ggplot2 plot
 #' @export
@@ -52,7 +53,7 @@ ggbiplot <- function(pcobj, choices = 1:2, scale = 1, pc.biplot = TRUE,
                       var.axes = TRUE, 
                       circle = FALSE, circle.prob = 0.69, 
                       varname.size = 3, varname.adjust = 1.5, 
-                      varname.abbrev = FALSE, ...)
+                      varname.abbrev = FALSE, nvars=NULL, ...)
 {
   library(ggplot2)
   library(plyr)
@@ -147,6 +148,16 @@ ggbiplot <- function(pcobj, choices = 1:2, scale = 1, pc.biplot = TRUE,
   g <- ggplot(data = df.u, aes(x = xvar, y = yvar)) + 
           xlab(u.axis.labs[1]) + ylab(u.axis.labs[2]) + coord_equal()
 
+
+  # Select nvars variables to plot based on PC loading
+  if(!is.null(nvars))  {
+      nvars <- min(dim(df.v)[1], nvars)
+      df.v$loading = df.v$xvar ^ 2 + df.v$yvar ^ 2
+      o <- order(df.v$loading, decreasing=TRUE)
+      df.v <- df.v[o[1:nvars],]
+  }
+
+  
   if(var.axes) {
     # Draw circle
     if(circle) 

--- a/R/ggbiplot.r
+++ b/R/ggbiplot.r
@@ -38,6 +38,7 @@
 #' @param varname.adjust  adjustment factor the placement of the variable names, >= 1 means farther from the arrow
 #' @param varname.abbrev  whether or not to abbreviate the variable names
 #' @param nvars           number of variables to plot
+#' @param var.sizefactor  multiplier for size of arrows
 #'
 #' @return                a ggplot2 plot
 #' @export
@@ -53,7 +54,8 @@ ggbiplot <- function(pcobj, choices = 1:2, scale = 1, pc.biplot = TRUE,
                       var.axes = TRUE, 
                       circle = FALSE, circle.prob = 0.69, 
                       varname.size = 3, varname.adjust = 1.5, 
-                      varname.abbrev = FALSE, nvars=NULL, ...)
+                      varname.abbrev = FALSE, nvars=NULL,
+                      var.sizefactor=NULL, ...)
 {
   library(ggplot2)
   library(plyr)
@@ -149,12 +151,18 @@ ggbiplot <- function(pcobj, choices = 1:2, scale = 1, pc.biplot = TRUE,
           xlab(u.axis.labs[1]) + ylab(u.axis.labs[2]) + coord_equal()
 
 
-  # Select nvars variables to plot based on PC loading
+  # Select nvars variables to plot
   if(!is.null(nvars))  {
       nvars <- min(dim(df.v)[1], nvars)
-      df.v$loading = df.v$xvar ^ 2 + df.v$yvar ^ 2
+      df.v$loading <- df.v$xvar ^ 2 + df.v$yvar ^ 2
       o <- order(df.v$loading, decreasing=TRUE)
       df.v <- df.v[o[1:nvars],]
+  }
+
+  # Scale x and y position of var arrows
+  if(!is.null(var.sizefactor)) {
+      df.v$xvar <- df.v$xvar * var.sizefactor
+      df.v$yvar <- df.v$yvar * var.sizefactor
   }
 
   


### PR DESCRIPTION
I've made some changes to allow the user to choose the number of variables to draw arrows for. The parameter nvars is the number of variables, and the parameter var.sizefactor is a linear multiplier that affects the size of arrows in the plot. For gene expression data, there's usually > 20k variables, and we want to draw the vectors for variables that are the top contributors to the displayed PCs. We sort the variables based on the radius of the projections on the two PCs displayed and select the top nvars.